### PR TITLE
Smaller appmenu icons

### DIFF
--- a/internal/ui/appmenu/appmenu.go
+++ b/internal/ui/appmenu/appmenu.go
@@ -105,22 +105,22 @@ func (a *AppMenu) setup() {
 	scaleFactor := a.treeView.GetScaleFactor()
 	var imageTags, imageSearch, imageSettings, imageStatus, imageDownloaded, imageInProgress *gdk.Pixbuf
 
+	// HiDPI hack while the required cairo stuff is missing in gotk3
+	// See https://gitlab.gnome.org/GNOME/gtk/-/issues/613
 	if scaleFactor == 1 {
-		imageTags = resources.Pixbuf("ui/appmenu/tags.svg")
-		imageSettings = resources.Pixbuf("ui/appmenu/settings.svg")
-		imageStatus = resources.Pixbuf("ui/appmenu/index.svg")
-		imageSearch = resources.Pixbuf("ui/appmenu/search.svg")
-		imageDownloaded = resources.Pixbuf("ui/appmenu/downloads.svg")
-		imageInProgress = resources.Pixbuf("ui/appmenu/in-progress.svg")
+		imageTags = resources.ScaledPixbuf(48, 48, "ui/appmenu/tags.svg")
+		imageSettings = resources.ScaledPixbuf(48, 48, "ui/appmenu/settings.svg")
+		imageStatus = resources.ScaledPixbuf(48, 48, "ui/appmenu/index.svg")
+		imageSearch = resources.ScaledPixbuf(48, 48, "ui/appmenu/search.svg")
+		imageDownloaded = resources.ScaledPixbuf(48, 48, "ui/appmenu/downloads.svg")
+		imageInProgress = resources.ScaledPixbuf(48, 48, "ui/appmenu/in-progress.svg")
 	} else {
-		// HiDPI hack while the required cairo stuff is missing in gotk3
-		// See https://gitlab.gnome.org/GNOME/gtk/-/issues/613
-		imageTags = resources.ScaledPixbuf(64, 64, "ui/appmenu/tags.svg")
-		imageSettings = resources.ScaledPixbuf(64, 64, "ui/appmenu/settings.svg")
-		imageStatus = resources.ScaledPixbuf(64, 64, "ui/appmenu/index.svg")
-		imageSearch = resources.ScaledPixbuf(64, 64, "ui/appmenu/search.svg")
-		imageDownloaded = resources.ScaledPixbuf(64, 64, "ui/appmenu/downloads.svg")
-		imageInProgress = resources.ScaledPixbuf(64, 64, "ui/appmenu/in-progress.svg")
+		imageTags = resources.ScaledPixbuf(42, 42, "ui/appmenu/tags.svg")
+		imageSettings = resources.ScaledPixbuf(42, 42, "ui/appmenu/settings.svg")
+		imageStatus = resources.ScaledPixbuf(42, 42, "ui/appmenu/index.svg")
+		imageSearch = resources.ScaledPixbuf(42, 42, "ui/appmenu/search.svg")
+		imageDownloaded = resources.ScaledPixbuf(42, 42, "ui/appmenu/downloads.svg")
+		imageInProgress = resources.ScaledPixbuf(42, 42, "ui/appmenu/in-progress.svg")
 	}
 
 	// Add some rows to the list store


### PR DESCRIPTION
The original size was intentional, but after testing a few different
sizes I actually like them a tad smaller.

Original:

![Screenshot from 2021-01-12 21-40-30_shadow](https://user-images.githubusercontent.com/10998/104622957-2a4f8300-5692-11eb-9f95-3f4f9a001819.png)

New size:

![Screenshot from 2021-01-14 17-54-46_shadow](https://user-images.githubusercontent.com/10998/104622488-9f6e8880-5691-11eb-8d40-73d0a172b028.png)

Suggested by @rawtaz

